### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Code for the Desktop Weather build
 
 Libraries needed:
 
-Requests - ```pip install requests```
+Requests - ```apt-get install python3-pip -y```
 
 
 Crontab setup needed:


### PR DESCRIPTION
RaspiOS armhf based on Bullseye does not pre-install Python3 or pip. Installing python3-pip includes requests library.

```bash
$ sudo pip3 install requests
Looking in indexes: https://pypi.org/simple, https://www.piwheels.org/simple
Requirement already satisfied: requests in /usr/lib/python3/dist-packages (2.25.1)
```